### PR TITLE
Use a Git submodule to import Contracts

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "contracts"]
+	path = contracts
+	url = git@github.com:archethic-foundation/bridge-contracts.git

--- a/contracts
+++ b/contracts
@@ -1,1 +1,0 @@
-/Users/SSe/SSe/app/ARCHETHIC/bridge-contracts/


### PR DESCRIPTION
This allows multiple developers to compile project, without  updating the `contract` link.