### PR TITLE
fix: :bug: Display error's reason when ContractFunctionRevertedError …

### DIFF
--- a/lib/domain/usecases/bridge_evm_process_mixin.dart
+++ b/lib/domain/usecases/bridge_evm_process_mixin.dart
@@ -494,6 +494,9 @@ mixin EVMBridgeProcessMixin {
               cause: 'This pool cannot received ethers',
             );
           default:
+            if (errorName.isEmpty && e.cause?.details?['reason'] != null) {
+              throw aedappfm.Failure.other(cause: e.cause?.details?['reason']);
+            }
             throw aedappfm.Failure.other(cause: e.shortMessage);
         }
       }


### PR DESCRIPTION
…doesn't come from ae contract

See tests in the issue